### PR TITLE
Release files are now stored in channel specific subfolders.

### DIFF
--- a/build.default.properties
+++ b/build.default.properties
@@ -14,7 +14,7 @@ os.family = linux
 github.url = https://github.com/tdproject/${ant.project.name}.git
 
 # ---- Module Release Settings --------------------------------------------------
-release.version = 0.1.50
+release.version = 0.1.51
 release.stability = beta
 
 # ---- Module Api Settings ------------------------------------------------------
@@ -34,7 +34,7 @@ mysql.password = tdproject
 mysql.database = tdproject_${ant.project.name}
 
 # ---- TDProject Release Settings --------------------------------------------------
-tdproject.version = 1.0.3
+tdproject.version = 1.0.9
 
 # ---- Instance Settings --------------------------------------------------------
 instance.base.dir = tdproject

--- a/pear/package2.xml
+++ b/pear/package2.xml
@@ -21,7 +21,7 @@
         <api>${api.stability}</api>
     </stability>
     <license uri="http://www.gnu.org/licenses/gpl-2.0.html">GPL, version 2.0</license>
-    <notes>Bugfixing invalid release delete() functionality</notes>
+    <notes>Release files are now stored in channel specific subfolders. Including legacy fallback logic.</notes>
     <dependencies>
         <required>
             <php>
@@ -61,6 +61,21 @@
     <phprelease/>
     <changelog>
 		<release xmlns="">
+                    <version>
+                        <release>0.1.51</release>
+                        <api>0.1.0</api>
+                    </version>
+                    <stability>
+                        <release>beta</release>
+                        <api>beta</api>
+                    </stability>
+                    <date>2014-12-15</date>
+                    <license uri="http://www.gnu.org/licenses/gpl-2.0.html">GPL, version 2.0</license>
+                    <notes>
+                        Release files are now stored in channel specific subfolders. Including legacy fallback logic.
+                    </notes>
+                </release>
+<release xmlns="">
                     <version>
                         <release>0.1.50</release>
                         <api>0.1.0</api>

--- a/src/app/code/core/TDProject/Channel/Common/Exceptions/ReleaseFileNotFoundException.php
+++ b/src/app/code/core/TDProject/Channel/Common/Exceptions/ReleaseFileNotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * TDProject_Channel_Common_Exceptions_DelegateException
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Open Software License (OSL 3.0)
+ * that is available through the world-wide-web at this URL:
+ * http://opensource.org/licenses/osl-3.0.php
+ */
+
+/**
+ * @category    TProject
+ * @package     TDProject_Channel
+ * @copyright   Copyright (c) 2014 <info@techdivision.com> - TechDivision GmbH
+ * @license     http://opensource.org/licenses/osl-3.0.php
+ *              Open Software License (OSL 3.0)
+ * @author      Markus Stockbauer <ms@techdivision.com>
+ */
+class TDProject_Channel_Common_Exceptions_ReleaseFileNotFoundException extends Exception {
+}


### PR DESCRIPTION
Including legacy fallback logic.
